### PR TITLE
sets up the initial imports for Redux and a mock reducer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,16 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import reportWebVitals from './reportWebVitals';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+import reducers from './reducers';
 
 import App from './App';
 
 ReactDOM.render(
-    <App />,
+  <Provider store={createStore(reducers)}>
+    <App />
+  </Provider>,
   document.getElementById('root')
 );
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,0 +1,7 @@
+import { combineReducers } from 'redux';
+
+
+export default combineReducers({
+    replaceMe: () => 'Hi there'
+
+});


### PR DESCRIPTION
This adds the necessary setup and imports to use Redux.  Also a directory is created for the reducers, and a mock or dummy reducer is provided.

In the main `index.js` file, a `Provider` is imported from `react-redux`.  Also a `createStore` is imported from `redux`.  While here, another `import` is set up for the reducers to come, by importing `reducers` from the `reducers` directory.  In the `ReactDOM.render`, the `<Provider`> tag is then wrapped around the `<App>` component being rendered.  Inside the `<Provider>` tag a prop of `store` is provided with a value of `createStore`, which is passed in a value of `reducers`.

Then a directory is set up named `reducers`, and a main file is created here named `index.js`.  In this file, a `combineReducers` is imported from `redux`.  For now, a default export is added at the bottom, that exports the `combineReducers`.  A mock, or dummy, value is passed to this, with the key of `replaceMe` that will return a function that simply says "Hi there" for testing.