### PR TITLE
adds api directory and incorporates redux thunk middleware

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,5 +1,7 @@
-export const fetchPosts = () => {
-    return {
-        type: "FETCH_POSTS"
-    };
+import jsonPlaceholder from '../apis/jsonPlaceholder';
+
+export const fetchPosts = () => async dispatch => {    
+    const response = await jsonPlaceholder.get('/posts');
+
+    dispatch({ type: "FETCH_POSTS", payload: response });
 };

--- a/src/apis/jsonPlaceholder.js
+++ b/src/apis/jsonPlaceholder.js
@@ -1,0 +1,5 @@
+import axios from 'axios';
+
+export default axios.create({
+    baseURL:'https://jsonplaceholder.typicode.com/'
+});

--- a/src/index.js
+++ b/src/index.js
@@ -2,13 +2,16 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import reportWebVitals from './reportWebVitals';
 import { Provider } from 'react-redux';
-import { createStore } from 'redux';
-import reducers from './reducers';
+import { createStore, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
 
+import reducers from './reducers';
 import App from './App';
 
+const store = createStore(reducers, applyMiddleware(thunk));
+
 ReactDOM.render(
-  <Provider store={createStore(reducers)}>
+  <Provider store={store}>
     <App />
   </Provider>,
   document.getElementById('root')


### PR DESCRIPTION
An `apis` directory is added, with a file name of `jsonPlaceholder`.  In this file, `axios` is imported.  The an `axios.create` is added that is provided a `baseURL` of 'https://jsonplaceholder.typicode.com/', to eventually pull the necessary data from.  This axios api call is then set to be the `export default`. 

In the main `index.js` file in the `src` directory, the `applyMiddleware` is imported from `redux`.  Also, `thunk` is imported from `redux-thunk`.  Below the imports, a variable is made named `store`.  In this variable, it extracts the logic for the `store` used inside the `Provider`.  A second value of `applyMiddleware`, with its own parameter of `thunk`, is then passed into `createStore`.  Then in the `Provider` itself, a single `{store}` is provided for its `store` value.

In `actions/index.js`, the `jsonPlaceholder` is imported from its file.  Now the `fetchPosts` function is updated to have an `async`/`await` setup.  The `fetchPosts` makes use of Redux Thunk middleware by returning a function with the parameter of `dispatch`.  A variable named `response` set to `await` so that axios can fetch the data from the `jsonPlaceholder` api.   It is set to use `.get` to retrieve the '/posts/' path.  Now `dispatch` is used to add a `payload`, with the value coming back from the api `response`, that is captured in that variable.

