### PR TITLE
configures state as props to the PostList component

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -4,5 +4,5 @@ import jsonPlaceholder from '../apis/jsonPlaceholder';
 export const fetchPosts = () => async dispatch => {    
     const response = await jsonPlaceholder.get('/posts');
 
-    dispatch({ type: "FETCH_POSTS", payload: response });
+    dispatch({ type: "FETCH_POSTS", payload: response.data });
 };

--- a/src/components/PostList.js
+++ b/src/components/PostList.js
@@ -3,18 +3,23 @@ import { connect } from 'react-redux';
 import { fetchPosts } from '../actions';
 
 class PostList extends Component {
-    componentDidMount () {
+    componentDidMount() {
         this.props.fetchPosts();
     };
 
     render() {
+        console.log(this.props.posts);
         return (
             <div>Post List</div>
         )
     };
 };
 
+const mapStateToProps = (state) => {
+    return { posts: state.posts };
+}
+
 export default connect(
-    null,
+    mapStateToProps,
     { fetchPosts }
 )(PostList);

--- a/src/reducers/postsReducer.js
+++ b/src/reducers/postsReducer.js
@@ -1,6 +1,6 @@
 /* eslint import/no-anonymous-default-export: [2, {"allowArrowFunction": true}] */
 export default (state = [], action) => {
-    switch (action) {
+    switch (action.type) {
         case "FETCH_POSTS":
             return action.payload;
         default:


### PR DESCRIPTION
In the `PostList` component, a `mapStateToProps` function is defined.  It takes a single argument of `state`.  It then returns an object where `posts` is set to the value of `state.posts`, coming from the `/reducers/index.js` file.  This is then handed off as the first argument to the `connect` function.  In the `PostList` component's `render`, a `console.log` is added to have the state data show up in the console.

An adjustment is made in the `reducers/PostReducer.js` file so that the `switch` statement now takes `action.type` as its argument.

In the `actions/index.js` file, the `payload` property for `FETCH_POSTS` is adjusted to pull in the `data` specifically, instead of the entire `response`.