### PR TITLE
adds the semantic-ui library

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,6 +15,7 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.css" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.


### PR DESCRIPTION
This added the Semantic-UI library to the app.  In the `index.html` file, a `link` is added as a `stylesheet`, that directs to the Semantic-UI minified CDN.  This library was used instead of the previously referenced Material UI.