### PR TITLE
refactors UserHeader logic to mapStateToProps using ownProps

### DIFF
--- a/src/components/UserHeader.js
+++ b/src/components/UserHeader.js
@@ -8,7 +8,7 @@ class UserHeader extends Component {
     }
 
     render() {
-        const user = this.props.users.find((user) => user.id === this.props.userId);
+        const { user } = this.props;
 
         if(!user) {
             return null;
@@ -18,8 +18,8 @@ class UserHeader extends Component {
     }
 }
 
-const mapStateToProps = (state) => {
-    return {users: state.users};
+const mapStateToProps = (state, ownProps) => {
+    return {user: state.users.find( user => user.id === ownProps.userId)};
 }
 
 export default connect (mapStateToProps, { fetchUser })(UserHeader);


### PR DESCRIPTION
In the `UserHeader` component, the logic inside the `render` method to locate the specific user is relocated to the `mapStateToProps` function.  Inside this function, an additional argument is passed in along with `state`, with the name of `ownProps`, to get access the components props.  The `users` property is renamed to be a singular `user`.  Then `find` is ran on `state.users` to check if each `user.id` is equal to the `ownProps.userId`.   Then in the `render` method, the `user` variable is extracted out of `this.props`.