### PR TITLE
sets up action creator for addressing duplicate requests

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,6 +1,13 @@
 import jsonPlaceholder from '../apis/jsonPlaceholder';
+import _ from 'lodash';
 
 // use Redux Thunk middleware to return a function with a dispatch argument
+export const fetchPostsAndUsers = () => async (dispatch, getState) => {
+    await dispatch(fetchPosts());
+    const userIds = _.uniq(_.map(getState().posts, 'userId'));
+    userIds.forEach(id => dispatch(fetchUser(id)));
+}
+
 export const fetchPosts = () => async dispatch => {    
     const response = await jsonPlaceholder.get('/posts');
 

--- a/src/components/PostList.js
+++ b/src/components/PostList.js
@@ -1,11 +1,11 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { fetchPosts } from '../actions';
+import { fetchPostsAndUsers } from '../actions';
 import UserHeader from './UserHeader';
 
 class PostList extends Component {
     componentDidMount() {
-        this.props.fetchPosts();
+        this.props.fetchPostsAndUsers();
     };
 
     renderList = () => {
@@ -38,5 +38,5 @@ const mapStateToProps = (state) => {
 
 export default connect(
     mapStateToProps,
-    { fetchPosts }
+    { fetchPostsAndUsers }
 )(PostList);


### PR DESCRIPTION
This sets up a new action creator to address the issue of making duplicate requests for the user ID.

In the `actions/index.js` file, a new action creator is created with the name `fetchPostsAndUsers`.  This uses the Redux Thunk middleware as well, by using an arrow function that is an `async` function.  This takes 2 arguments, which are `dispatch` and `getState`.  It then returns `fetchPosts` that is invoked by running `dispatch` on this function.  This returned function is given the `await` keyword so that it doesn't continue running code in the function until it's retrieved the post information.  
Next a variable is made named `userIds`.  It is set to call `getState` and reference the `posts` property.  We then iterate through the list of posts to find the unique Ids, by using Lodash's version of the `map` function, which is `_.map`, which is passed in the list of posts as the first argument.  A second argument of `userId` is passed in.  To get the unique user Ids, the Lodash `_uniq` is used.  Then we iterate over these `userIds` using `forEach`, and for each `id`, we call `fetchUser` and pass in that `id`.  The result is then dispatched.

In `PostList.js`, the action that's imported is changed to the new `fetchPostsAndUsers`.  This same action creator is updated in the `componentDidMount`, and in the `connect` function found in the `export` at the bottom.