### PR TITLE
refactors UserHeader component to no longer fetch own data

### DIFF
--- a/src/components/UserHeader.js
+++ b/src/components/UserHeader.js
@@ -1,11 +1,12 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { fetchUser } from '../actions';
+// No longer necessary for component to fetch own data
+// import { fetchUser } from '../actions';
 
 class UserHeader extends Component {
-    componentDidMount() {
-        this.props.fetchUser(this.props.userId);
-    }
+    // componentDidMount() {
+    //     this.props.fetchUser(this.props.userId);
+    // }
 
     render() {
         const { user } = this.props;
@@ -22,4 +23,5 @@ const mapStateToProps = (state, ownProps) => {
     return {user: state.users.find( user => user.id === ownProps.userId)};
 }
 
-export default connect (mapStateToProps, { fetchUser })(UserHeader);
+// export default connect (mapStateToProps, { fetchUser })(UserHeader);
+export default connect (mapStateToProps)(UserHeader);


### PR DESCRIPTION
A refactor is done to the `UserHeader` Component, since the new action creator `fetchPostsandUsers` is now being used.  
In `UserHeader.js`, some code that is no longer needed is removed by commenting it out, so it can still remain as a reference.  The `import` for the `fetchUser` action creator is commented out. A comment is also added above this that explains why the code was removed.  In the component, the `componentDidMount` is also commented out, along with it's call to the `fetchUser` action creator.  Then in the `export` at the bottom, the `fetchUser` action is again removed, this time from the `connect` function.  A commented out line is kept again for reference.