### PR TITLE
comments added to UserHeader component

### DIFF
--- a/src/components/UserHeader.js
+++ b/src/components/UserHeader.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 // import { fetchUser } from '../actions';
 
 class UserHeader extends Component {
+    // No longer necessary for component to fetch own data
     // componentDidMount() {
     //     this.props.fetchUser(this.props.userId);
     // }
@@ -23,5 +24,6 @@ const mapStateToProps = (state, ownProps) => {
     return {user: state.users.find( user => user.id === ownProps.userId)};
 }
 
+// No longer necessary for component to fetch own data
 // export default connect (mapStateToProps, { fetchUser })(UserHeader);
 export default connect (mapStateToProps)(UserHeader);


### PR DESCRIPTION
This adds a couple comments to the UserHeader component.  In the `UserHeader.js` file, some additional comments were added. 
These specify why certain code that previously pertained to the component fetching it's own data, is now commented out.  The comments add that the component is no longer fetching it's own data, which is due to the recently added `fetchPostsAndUsers` action creator.